### PR TITLE
Free cmd Memory parser and Error Handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The .exe can be built for windows (on linux) as:
 
 Or it can be compiled on windows as:
 
-`$env:GOOS="windows; $env:GOARCH="amd64";C:\Go\bin\go build -o perfmonitor.exe`
+`$env:GOOS="windows"; $env:GOARCH="amd64";C:\Go\bin\go build -o perfmonitor.exe`
 
 Linux executable can be created with the following command:
 

--- a/README.md
+++ b/README.md
@@ -24,22 +24,26 @@ data is returned in the following JSON format (this is windows example, Keys won
 
 ```javascript
 [  
-   {  
-      "Date":"6/9/2019 10:16:39 PM",
-      "Key":"\\\\pc-name\\logicaldisk(q:)\\% free space",
-      "Value":"60.1844908902267"
-   },
-   {  
-      "Date":"6/9/2019 10:16:39 PM",
-      "Key":"\\\\pc-name\\processor information(0,0)\\% processor time",
-      "Value":"17.484500998004"
-   },
-   {  
-      "Date":"6/9/2019 10:16:39 PM",
-      "Key":"\\\\pc-name\\memory\\available bytes",
-      "Value":"3154997248"
-   }
-   ...
+   "status": "success",
+   "message": "",
+   "data": [
+      {  
+         "Date":"6/9/2019 10:16:39 PM",
+         "Key":"\\\\pc-name\\logicaldisk(q:)\\% free space",
+         "Value":"60.1844908902267"
+      },
+      {  
+         "Date":"6/9/2019 10:16:39 PM",
+         "Key":"\\\\pc-name\\processor information(0,0)\\% processor time",
+         "Value":"17.484500998004"
+      },
+      {  
+         "Date":"6/9/2019 10:16:39 PM",
+         "Key":"\\\\pc-name\\memory\\available bytes",
+         "Value":"3154997248"
+      }
+      ...
+   ]
 ]
 ```
 
@@ -51,8 +55,12 @@ $ curl -i "http://{{vm_host}}:9159/platform"
 
 ```javascript
 {
-   "machine":"my.hostname",
-   "platform":"linux" // or "windows"
+   "status": "success",
+   "message": "",
+   "data": {
+      "machine":"my.hostname",
+      "platform":"linux" // or "windows"
+   }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,28 +23,28 @@ $ curl -i "http://{{vm_host}}:9159/sysstats"
 data is returned in the following JSON format (this is windows example, Keys won't match the linux output):
 
 ```javascript
-[  
+{
    "status": "success",
    "message": "",
    "data": [
       {  
-         "Date":"6/9/2019 10:16:39 PM",
-         "Key":"\\\\pc-name\\logicaldisk(q:)\\% free space",
-         "Value":"60.1844908902267"
+         "date":"6/9/2019 10:16:39 PM",
+         "key":"\\\\pc-name\\logicaldisk(q:)\\% free space",
+         "value":"60.1844908902267"
       },
       {  
-         "Date":"6/9/2019 10:16:39 PM",
-         "Key":"\\\\pc-name\\processor information(0,0)\\% processor time",
-         "Value":"17.484500998004"
+         "date":"6/9/2019 10:16:39 PM",
+         "key":"\\\\pc-name\\processor information(0,0)\\% processor time",
+         "value":"17.484500998004"
       },
       {  
-         "Date":"6/9/2019 10:16:39 PM",
-         "Key":"\\\\pc-name\\memory\\available bytes",
-         "Value":"3154997248"
+         "date":"6/9/2019 10:16:39 PM",
+         "key":"\\\\pc-name\\memory\\available bytes",
+         "value":"3154997248"
       }
       ...
    ]
-]
+}
 ```
 
 You can find os of the vm `perfmonitor` is running on by querying:

--- a/perfmonitor.go
+++ b/perfmonitor.go
@@ -23,12 +23,12 @@ type response struct {
 	Message string      `json:"message"`
 }
 
-type getData func() (interface{}, error)
+type getResponseData func() (interface{}, error)
 
-func processRequest(w http.ResponseWriter, f getData) {
+func processRequest(w http.ResponseWriter, getData getResponseData) {
 	w.Header().Set("Content-Type", "application/json")
 
-	data, err := f()
+	data, err := getData()
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/perfmonitor.service
+++ b/perfmonitor.service
@@ -2,7 +2,7 @@
 Description=Perfmonitor tool collecting system performance
 
 [Service]
-Type=idle
+Type=simple
 Restart=always
 RestartSec=3
 ExecStart=/usr/bin/perfmonitor

--- a/perfstats/perfstats_linux.go
+++ b/perfstats/perfstats_linux.go
@@ -2,6 +2,7 @@ package perfstats
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -167,7 +168,7 @@ func getMemoryStats() SysStat {
 }
 
 // PlatformSysStats Query performance stats on linux platform
-func PlatformSysStats() ([]SysStat, error) {
+func PlatformSysStats() (interface{}, error) {
 
 	var stats []SysStat
 	stats = append(stats, getCPUStats()...)
@@ -179,5 +180,5 @@ func PlatformSysStats() ([]SysStat, error) {
 	// 	fmt.Println(err)
 	// }
 
-	return stats, nil
+	return stats, errors.New("bad bad error")
 }

--- a/perfstats/perfstats_linux.go
+++ b/perfstats/perfstats_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,15 @@ const (
 	procCPUSoftirq = iota
 	procCPUSteal   = iota
 	procCPUGuest   = iota
+)
+
+const (
+	memoryTotal     = iota
+	memoryUsed      = iota
+	memoryFree      = iota
+	memoryShared    = iota
+	memoryBuffCache = iota
+	memoryAvailable = iota
 )
 
 // convert proc time samples to float
@@ -68,6 +78,12 @@ func parseProcStat() map[string][]float64 {
 	return cpuStats
 }
 
+func getDateFormatted() string {
+	// match date format returned by win
+	dt := time.Now()
+	return dt.Format("1/2/2006 3:04:05 PM")
+}
+
 // compute active and total CPU utilizations from proc/stat readings
 func computeActiveTotalCPU(procStats map[string][]float64) (map[string]float64, map[string]float64) {
 
@@ -99,10 +115,7 @@ func getCPUStats() []SysStat {
 	var sysStats []SysStat
 	var statEntry SysStat
 
-	// match date format returned by win
-	dt := time.Now()
-	dateFormatted := dt.Format("1/2/2006 3:04:05 PM")
-
+	dateFormatted := getDateFormatted()
 	timeBetweenSamples := 2 * time.Second
 
 	// sample 2 stats with a time-delay in between
@@ -126,11 +139,40 @@ func getCPUStats() []SysStat {
 	return sysStats
 }
 
+func getMemoryStats() SysStat {
+
+	var memStat SysStat
+
+	const (
+		header = iota
+		memory = iota
+		swap   = iota
+	)
+
+	cmdResult := exec.Command("free", "--bytes")
+
+	out, err := cmdResult.Output()
+	if err != nil {
+		fmt.Println(err)
+		return memStat
+	}
+
+	// get total, used, free etc. (discard first token sicne it's a label "Mem:")
+	memInfo := strings.Fields(strings.Split(string(out[:]), "\n")[memory])[1:]
+
+	memStat.Date = getDateFormatted()
+	memStat.Key = "Memory Available"
+	memStat.Value = memInfo[memoryAvailable]
+
+	return memStat
+}
+
 // PlatformSysStats Query performance stats on linux platform
 func PlatformSysStats() []byte {
 
 	var stats []SysStat
 	stats = append(stats, getCPUStats()...)
+	stats = append(stats, getMemoryStats())
 
 	jsonData, err := json.Marshal(stats)
 	if err != nil {

--- a/perfstats/perfstats_linux.go
+++ b/perfstats/perfstats_linux.go
@@ -2,7 +2,6 @@ package perfstats
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -168,17 +167,17 @@ func getMemoryStats() SysStat {
 }
 
 // PlatformSysStats Query performance stats on linux platform
-func PlatformSysStats() []byte {
+func PlatformSysStats() ([]SysStat, error) {
 
 	var stats []SysStat
 	stats = append(stats, getCPUStats()...)
 	stats = append(stats, getMemoryStats())
 
-	jsonData, err := json.Marshal(stats)
-	if err != nil {
-		fmt.Println("Error!")
-		fmt.Println(err)
-	}
+	// jsonData, err := json.Marshal(stats)
+	// if err != nil {
+	// 	fmt.Println("Error!")
+	// 	fmt.Println(err)
+	// }
 
-	return jsonData
+	return stats, nil
 }

--- a/perfstats/perfstats_windows.go
+++ b/perfstats/perfstats_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Convert sysStat in csv format to json
-func sysStatCSVToJSON(cmdOut []byte) []byte {
+func sysStatCSVToSysStat(cmdOut []byte) SysStat {
 
 	reader := csv.NewReader(bytes.NewReader(cmdOut))
 	reader.FieldsPerRecord = -1
@@ -59,6 +59,6 @@ func queryWindowsSysStats() []byte {
 	return out
 }
 
-func PlatformSysStats() []byte {
-	return sysStatCSVToJSON(queryWindowsSysStats())
+func PlatformSysStats() ([]SysStat, error) {
+	return sysStatCSVToSysStat(queryWindowsSysStats()), nil
 }

--- a/perfstats/perfstats_windows.go
+++ b/perfstats/perfstats_windows.go
@@ -59,6 +59,6 @@ func queryWindowsSysStats() []byte {
 	return out
 }
 
-func PlatformSysStats() ([]SysStat, error) {
+func PlatformSysStats() (interface{}, error) {
 	return sysStatCSVToSysStat(queryWindowsSysStats()), nil
 }

--- a/perfstats/sysstat.go
+++ b/perfstats/sysstat.go
@@ -13,11 +13,12 @@ type SysStat struct {
 }
 
 // GetPlatformInfo show platform details
-func GetPlatformInfo() (map[string]string, error) {
+func GetPlatformInfo() (interface{}, error) {
 
 	hostname, _ := os.Hostname()
-	return map[string]string{
+	machineDetails := map[string]string{
 		"platform": runtime.GOOS,
 		"machine":  hostname,
-	}, nil
+	}
+	return machineDetails, nil
 }

--- a/perfstats/sysstat.go
+++ b/perfstats/sysstat.go
@@ -1,32 +1,23 @@
 package perfstats
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"runtime"
 )
 
 // SysStat Performance statistics
 type SysStat struct {
-	Date  string // date when stat item was grabbed
-	Key   string // type of sys stats (memory, cpu etc.)
-	Value string // current value of sys stat (cpu usage %, free space)
+	Date  string `json:"date"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // GetPlatformInfo show platform details
-func GetPlatformInfo() []byte {
+func GetPlatformInfo() (map[string]string, error) {
 
 	hostname, _ := os.Hostname()
-	jsonData, err := json.Marshal(map[string]string{
+	return map[string]string{
 		"platform": runtime.GOOS,
 		"machine":  hostname,
-	})
-
-	if err != nil {
-		fmt.Println("Error!")
-		fmt.Println(err)
-	}
-
-	return jsonData
+	}, nil
 }


### PR DESCRIPTION
Moving towards closing #5 

- This adds `free` cmd parser for linux to match windows script output, the endpoint `/sysstats` should report memory as "Available Bytes" on top of already implemented cpu performance parser
- Switched response format to this (to add status & error message if exists):
```
{
   "status": "success",
   "message": "",
   "data": [
      {  
         "date":"6/9/2019 10:16:39 PM",
         "key":"\\\\pc-name\\logicaldisk(q:)\\% free space",
         "value":"60.1844908902267"
      },
      ...
   ]
}
```
Note that I am planning to update `data` format for `/sysstats` so it's more or less consistent for all the platforms, I am keeping the `key`/`value`/`date` combination for now.
- Added better handling (based on [this](https://blog.golang.org/error-handling-and-go)) including setting error code on http headers, `500` is the only err code I am expecting atm 