### PR TITLE
Memory/Disk stats are reported in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Current performance stats can be accessed at HTTP port `:9159` & route `/sysstat
 $ curl -i "http://{{vm_host}}:9159/sysstats"
 ```
 
-On both platforms, `value` for harware type `cpu` or `memory` indicates the following:
+On both platforms, stats include the following performance indicators:
 
-- `cpu`: % Processor Time is the percentage of elapsed time that the processor spends to execute a non-Idle thread (CPU Utilization, see [Microsoft Docs](https://social.technet.microsoft.com/wiki/contents/articles/12984.understanding-processor-processor-time-and-process-processor-time.aspx))
-- `memory`: Memory Available in Bytes
+- cpu `utilization` — % Processor Time is the percentage of elapsed time that the processor spends to execute a non-Idle thread (CPU Utilization, see [Microsoft Docs](https://social.technet.microsoft.com/wiki/contents/articles/12984.understanding-processor-processor-time-and-process-processor-time.aspx))
+- memory `available` (in bytes)
+- disk `size`, `used` and `freeSpace` (all in bytes)
 
-For windows, `instanceName` indicates cpu instance or disk name if applicable;
+For windows, `instanceName` indicates cpu instance and `deviceID` stores disk drive letter:
 
 ```javascript
 {
@@ -51,7 +52,7 @@ For windows, `instanceName` indicates cpu instance or disk name if applicable;
                "timeBase": "10000000",
                "timestamp": "6\/19\/2019 10:52:59 AM",
                "timestamp100NSec": "132054151798539933",
-               "value": "9.41475786277403"
+               "utilization": "9.41475786277403"
             }
             { ... }
          ],
@@ -83,7 +84,7 @@ For windows, `instanceName` indicates cpu instance or disk name if applicable;
                "timeBase": "10000000",
                "timestamp": "6\/19\/2019 10:52:58 AM",
                "timestamp100NSec": "132054151780150000",
-               "value": "1515257856"
+               "available": "1515257856"
             }
          ],
          "date": "20190619145256"
@@ -105,8 +106,7 @@ Identification of hardware devices on linux differs from the windows output (for
          "stats": [
             {
                "cpuName": "cpu1",
-               "value": "7.575758",
-               "valueType": "% CPU Utilization"
+               "utilization": "16.580311"
             },
             { ... }
          ],
@@ -115,14 +115,13 @@ Identification of hardware devices on linux differs from the windows output (for
       "disk": {
          "stats": [
             {
-               "1K-blocks": "224021164",
-               "available": "171205740",
+               "1B-blocks": "229397671936",
                "filesystem": "/dev/mapper/fedora_localhost--live-home",
+               "freeSpace": "175291777024",
                "mounted": "/home",
+               "size": "229397671936",
                "use%": "20%",
-               "used": "41366080",
-               "value": "80.540186",
-               "valueType": "Space Available"
+               "used": "42381766656"
             },
             { ... }
         ],
@@ -131,8 +130,9 @@ Identification of hardware devices on linux differs from the windows output (for
       "memory": {
          "stats": [
             {
-               "value": "22358220800",
-               "valueType": "Memory Available (bytes)"
+               "available": "16094851072",
+               "total": "33646678016",
+               "used": "16707964928"
             }
          ],
          "date": "20190619145256"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Current performance stats can be accessed at HTTP port `:9159` & route `/sysstat
 $ curl -i "http://{{vm_host}}:9159/sysstats"
 ```
 
-On both platforms, `value` for a specific hardware group indicates performance measure in the following format:
+On both platforms, `value` for harware type `cpu` or `memory` indicates the following:
 
 - `cpu`: % Processor Time is the percentage of elapsed time that the processor spends to execute a non-Idle thread (CPU Utilization, see [Microsoft Docs](https://social.technet.microsoft.com/wiki/contents/articles/12984.understanding-processor-processor-time-and-process-processor-time.aspx))
-- `disk`: Percentage available of total storage space
 - `memory`: Memory Available in Bytes
 
 For windows, `instanceName` indicates cpu instance or disk name if applicable;
@@ -61,18 +60,10 @@ For windows, `instanceName` indicates cpu instance or disk name if applicable;
       "disk": {
          "stats": [
             {
-               "counterType": "RawFraction",
-               "defaultScale": "0",
-               "instanceName": "harddiskvolume1",
-               "multipleCount": "1",
-               "path": "\\\\desktop-fo9p270\\logicaldisk(harddiskvolume1)\\% free space",
-               "rawValue": "175",
-               "secondValue": "578",
-               "status": "0",
-               "timeBase": "10000000",
-               "timestamp": "6\/19\/2019 10:53:01 AM",
-               "timestamp100NSec": "132054151816460000",
-               "value": "30.2768166089965"
+               "deviceID": "C:",
+               "freeSpace": "18850095104",
+               "size": "42340446208",
+               "used": "23490351104"
             },
             { ... }
         ],

--- a/perfstats/perfstats_linux.go
+++ b/perfstats/perfstats_linux.go
@@ -171,19 +171,11 @@ func getMemoryStats() (StatEntry, error) {
 	return statEntry, nil
 }
 
-// Free returns usage%, get available % to match windows counter output
-func getSpaceAvailablePercentage(diskMap map[string]string) string {
-	availableSpace, _ := strconv.ParseFloat(diskMap["available"], 64)
-	usedSpace, _ := strconv.ParseFloat(diskMap["used"], 64)
-
-	return strconv.FormatFloat(availableSpace*100/(availableSpace+usedSpace), 'f', 6, 64)
-}
-
 func getDiskStats() (StatEntry, error) {
 	var statEntry StatEntry
 	var diskStats []map[string]string
 
-	cmdResult := exec.Command("df")
+	cmdResult := exec.Command("df", "-B1")
 	out, err := cmdResult.Output()
 	if err != nil {
 		return statEntry, err
@@ -212,8 +204,10 @@ func getDiskStats() (StatEntry, error) {
 			lineMap[headers[i]] = tokens[i]
 		}
 
-		lineMap["valueType"] = "Space Available"
-		lineMap["value"] = getSpaceAvailablePercentage(lineMap)
+		lineMap["size"] = lineMap["1B-blocks"]
+		lineMap["freeSpace"] = lineMap["available"]
+
+		delete(lineMap, "available")
 		diskStats = append(diskStats, lineMap)
 	}
 

--- a/perfstats/perfstats_linux.go
+++ b/perfstats/perfstats_linux.go
@@ -128,9 +128,8 @@ func getCPUStats() (StatEntry, error) {
 		fmtUtilization := strconv.FormatFloat(cpuUtilization, 'f', 6, 64)
 		// Populate returned cpu performance stats
 		cpuStats = append(cpuStats, map[string]string{
-			"cpuName":   cpuName,
-			"value":     fmtUtilization,
-			"valueType": "% CPU Utilization",
+			"cpuName":     cpuName,
+			"utilization": fmtUtilization,
 		})
 	}
 
@@ -164,8 +163,9 @@ func getMemoryStats() (StatEntry, error) {
 	statEntry.Stats = append(
 		memStats,
 		map[string]string{
-			"value":     memInfo[memoryAvailable],
-			"valueType": "Memory Available (bytes)",
+			"total":     memInfo[memoryTotal],
+			"used":      memInfo[memoryUsed],
+			"available": memInfo[memoryAvailable],
 		})
 
 	return statEntry, nil

--- a/perfstats/perfstats_windows.go
+++ b/perfstats/perfstats_windows.go
@@ -81,8 +81,9 @@ func getDiskStats() (StatEntry, error) {
 
 	var statEntry StatEntry
 
-	// Run powershell command returning a performance counter
-	getWmiCommand := "& {Get-WmiObject -Class Win32_logicaldisk "
+	// Query logical disk restricting drives to "local disk" type (#3)
+	getWmiCommand := "& {Get-WmiObject -Class Win32_logicaldisk -Filter \"DriveType = '3'\" "
+	// Get total, free and calculate used (all in bytes)
 	getWmiCommand += "| Select-Object -Property DeviceID, Size, FreeSpace, @{L=\"Used\";E={\"{0}\" -f ($_.Size-$_.FreeSpace)} } "
 	getWmiCommand += "| convertto-csv -NoTypeInformation}"
 	cmdResult := exec.Command("powershell.exe", "-executionpolicy", "bypass", "-Command", getWmiCommand)

--- a/perfstats/perfstats_windows.go
+++ b/perfstats/perfstats_windows.go
@@ -82,7 +82,9 @@ func getDiskStats() (StatEntry, error) {
 	var statEntry StatEntry
 
 	// Run powershell command returning a performance counter
-	getWmiCommand := "& {Get-WmiObject -Class Win32_logicaldisk | Select-Object -Property DeviceID, Size, FreeSpace | convertto-csv -NoTypeInformation}"
+	getWmiCommand := "& {Get-WmiObject -Class Win32_logicaldisk "
+	getWmiCommand += "| Select-Object -Property DeviceID, Size, FreeSpace, @{L=\"Used\";E={\"{0}\" -f ($_.Size-$_.FreeSpace)} } "
+	getWmiCommand += "| convertto-csv -NoTypeInformation}"
 	cmdResult := exec.Command("powershell.exe", "-executionpolicy", "bypass", "-Command", getWmiCommand)
 
 	out, err := cmdResult.Output()

--- a/perfstats/perfstats_windows.go
+++ b/perfstats/perfstats_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Convert csv to array of maps
-func parseCSVOutput(cmdOut []byte) ([]map[string]string, error) {
+func parseCSVOutput(cmdOut []byte, cookedHeader string) ([]map[string]string, error) {
 
 	var parsedCsv []map[string]string
 
@@ -30,7 +30,7 @@ func parseCSVOutput(cmdOut []byte) ([]map[string]string, error) {
 	// lowercase first letter and match value format with other platforms
 	for idx, header := range headers {
 		if header == "CookedValue" {
-			header = "value"
+			header = cookedHeader
 		}
 		headers[idx] = lowerFirst(header)
 	}
@@ -50,7 +50,7 @@ func parseCSVOutput(cmdOut []byte) ([]map[string]string, error) {
 }
 
 // Query windows counters with powershell command
-func getPerfCounter(counterName string) (StatEntry, error) {
+func getPerfCounter(counterName string, cookedHeader string) (StatEntry, error) {
 	var statEntry StatEntry
 
 	// Run powershell command returning a performance counter
@@ -65,7 +65,7 @@ func getPerfCounter(counterName string) (StatEntry, error) {
 	}
 
 	// process powershell response
-	statEntry.Stats, err = parseCSVOutput(out)
+	statEntry.Stats, err = parseCSVOutput(out, cookedHeader)
 	if err != nil {
 		return statEntry, err
 	}
@@ -74,7 +74,7 @@ func getPerfCounter(counterName string) (StatEntry, error) {
 }
 
 func getCPUStats() (StatEntry, error) {
-	return getPerfCounter("\\Processor Information(*)\\% Processor Time")
+	return getPerfCounter("\\Processor Information(*)\\% Processor Time", "utilization")
 }
 
 // get disk statistics using WmiObject ps command
@@ -97,7 +97,7 @@ func getDiskStats() (StatEntry, error) {
 		return statEntry, err
 	}
 
-	statEntry.Stats, err = parseCSVOutput(out)
+	statEntry.Stats, err = parseCSVOutput(out, "")
 	if err != nil {
 		return statEntry, err
 	}
@@ -107,5 +107,5 @@ func getDiskStats() (StatEntry, error) {
 }
 
 func getMemoryStats() (StatEntry, error) {
-	return getPerfCounter("\\Memory\\Available Bytes")
+	return getPerfCounter("\\Memory\\Available Bytes", "available")
 }

--- a/perfstats/sysstat.go
+++ b/perfstats/sysstat.go
@@ -37,7 +37,7 @@ func lowerFirst(str string) string {
 	return strings.ToLower(string(str[0])) + str[1:]
 }
 
-// GetPlatformInfo show platform details
+// GetPlatformInfo get platform details
 func GetPlatformInfo() (interface{}, error) {
 
 	hostname, err := os.Hostname()
@@ -50,7 +50,8 @@ func GetPlatformInfo() (interface{}, error) {
 }
 
 // PlatformSysStats Query performance stats
-// (calls either _linux.go or _windows perfstats implementations)
+// (calls either _linux.go or _windows perfstats implementations
+// depending on the platform it's running on)
 func PlatformSysStats() (interface{}, error) {
 
 	// find out current stats:

--- a/perfstats/sysstat.go
+++ b/perfstats/sysstat.go
@@ -9,7 +9,7 @@ import (
 )
 
 // AppVersion - current app version
-const AppVersion = "0.3.0"
+const AppVersion = "0.4.0"
 
 // StatEntry specific performance data sweep
 type StatEntry struct {


### PR DESCRIPTION
Fixes #10

Disk and memory performance stats are getting reported in bytes (as opposed to `% available`);
Plus updated output format so that `value` is replaced with more specific keys (`utilization`, `available` etc.)